### PR TITLE
Add a classMap for complex name resolution

### DIFF
--- a/src/jsonizer/fromjson.d
+++ b/src/jsonizer/fromjson.d
@@ -393,6 +393,10 @@ T fromJSONImpl(T, P)(JSONValue json, P parent, in ref JsonizeOptions options) {
     // look for class keyword in json
     auto className = json.fromJSON!string(options.classKey, null);
     // try creating an instance with Object.factory
+    if(options.classMap) {
+        if(auto tmp = options.classMap(className))
+          className = tmp;
+    }
     if (className !is null) {
       auto obj = Object.factory(className);
       assert(obj !is null, "failed to Object.factory " ~ className);

--- a/src/jsonizer/fromjson.d
+++ b/src/jsonizer/fromjson.d
@@ -393,7 +393,7 @@ T fromJSONImpl(T, P)(JSONValue json, P parent, in ref JsonizeOptions options) {
     // look for class keyword in json
     auto className = json.fromJSON!string(options.classKey, null);
     // try creating an instance with Object.factory
-    if(options.classMap) {
+    if (options.classMap) {
         if(auto tmp = options.classMap(className))
           className = tmp;
     }

--- a/src/jsonizer/internal/attribute.d
+++ b/src/jsonizer/internal/attribute.d
@@ -138,4 +138,6 @@ struct JsonizeOptions {
    * Setting `classKey` to null will disable factory construction.
    */
   string classKey = "class";
+
+  string delegate(string) classMap;
 }

--- a/src/jsonizer/internal/attribute.d
+++ b/src/jsonizer/internal/attribute.d
@@ -139,5 +139,14 @@ struct JsonizeOptions {
    */
   string classKey = "class";
 
+  /**
+   * A function to attempt identifier remapping from the name found under `classKey`.
+   *
+   * If this function is provided, then when the `classKey` is found, this function
+   * will attempt to remap the value.  Returned non-null values indicate that the
+   * remapping has succeeded.
+   *
+   * This is particularly useful when input JSON has not originated from D.
+   */
   string delegate(string) classMap;
 }

--- a/src/jsonizer/internal/attribute.d
+++ b/src/jsonizer/internal/attribute.d
@@ -143,8 +143,10 @@ struct JsonizeOptions {
    * A function to attempt identifier remapping from the name found under `classKey`.
    *
    * If this function is provided, then when the `classKey` is found, this function
-   * will attempt to remap the value.  Returned non-null values indicate that the
-   * remapping has succeeded.
+   * will attempt to remap the value.  This function should return either the fully
+   * qualified class name or null.  Returned non-null values indicate that the
+   * remapping has succeeded.  A null value will indicate the mapping has failed
+   * and the original value will be used in the object factory.
    *
    * This is particularly useful when input JSON has not originated from D.
    */


### PR DESCRIPTION
Enable complex name resolution of type names through the use of delegate function in the `JsonizeOptions` struct.  This great for resolving simple names in json documents into the fully qualified name needed for the object factory.
