### PR TITLE
add .lib to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __dummy.html
 
 # library
 *.a
+*.lib


### PR DESCRIPTION
This fixes an issue on Windows where, when building jsonizer from a git submodule, the build output (jsonizer.lib) flags the submodule as modified.